### PR TITLE
Add RegisterDriver

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,21 @@
+package assert
+
+import (
+	"testing"
+)
+
+func Err(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func NoErr(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -29,6 +29,7 @@ func TestRegisterDriver(t *testing.T) {
 
 func TestDB_Exec(t *testing.T) {
 	t.Run("select 1", func(t *testing.T) {
+		sqlite.RegisterDriver("")
 		db, err := sql.Open("sqlite", ":memory:")
 		assert.NoErr(t, err)
 		_, err = db.Exec(`select 1`)

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -4,26 +4,34 @@ import (
 	"database/sql"
 	"testing"
 
-	_ "github.com/maragudk/sqlite"
+	"github.com/maragudk/sqlite"
+	"github.com/maragudk/sqlite/internal/assert"
 )
 
-func TestDriver_Open(t *testing.T) {
-	t.Run("can open with driver name sqlite", func(t *testing.T) {
-		_, err := sql.Open("sqlite", "app.db")
-		if err != nil {
-			t.Fatal(err)
-		}
+func TestRegisterDriver(t *testing.T) {
+	t.Run("can open with default driver name sqlite", func(t *testing.T) {
+		sqlite.RegisterDriver("")
+		_, err := sql.Open("sqlite", ":memory:")
+		assert.NoErr(t, err)
+	})
+
+	t.Run("can open with custom driver name", func(t *testing.T) {
+		sqlite.RegisterDriver("foo")
+		_, err := sql.Open("foo", ":memory:")
+		assert.NoErr(t, err)
+	})
+
+	t.Run("errors on no register", func(t *testing.T) {
+		_, err := sql.Open("bar", ":memory:")
+		assert.Err(t, err)
 	})
 }
 
 func TestDB_Exec(t *testing.T) {
 	t.Run("select 1", func(t *testing.T) {
 		db, err := sql.Open("sqlite", ":memory:")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := db.Exec(`select 1`); err != nil {
-			t.Fatal(err)
-		}
+		assert.NoErr(t, err)
+		_, err = db.Exec(`select 1`)
+		assert.NoErr(t, err)
 	})
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -29,8 +29,8 @@ func TestRegisterDriver(t *testing.T) {
 
 func TestDB_Exec(t *testing.T) {
 	t.Run("select 1", func(t *testing.T) {
-		sqlite.RegisterDriver("")
-		db, err := sql.Open("sqlite", ":memory:")
+		sqlite.RegisterDriver("sqliteagain")
+		db, err := sql.Open("sqliteagain", ":memory:")
 		assert.NoErr(t, err)
 		_, err = db.Exec(`select 1`)
 		assert.NoErr(t, err)


### PR DESCRIPTION
Instead of `init`, use `RegisterDriver` to register the driver, giving the ability to use a custom name.

Also:
- De-export the rest of the interface.
- Provide error message helpers